### PR TITLE
feat(cmd): allow the baseDir to be passed as an argument

### DIFF
--- a/cmd/tk/debug.go
+++ b/cmd/tk/debug.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"log"
 	"path/filepath"
 
 	"github.com/sh0rez/tanka/pkg/jpath"
@@ -21,18 +21,21 @@ func debugCmd() *cobra.Command {
 func jpathCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "print information about the jpath",
-		Use:   "jpath",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			pwd, err := os.Getwd()
+		Use:   "jpath [directory]",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			pwd, err := filepath.Abs(args[0])
 			if err != nil {
-				return err
+				log.Fatalln(err)
 			}
-			path, base, root := jpath.Resolve(pwd)
+			path, base, root, err := jpath.Resolve(pwd)
+			if err != nil {
+				log.Fatalln("resolving jpath:", err)
+			}
 			fmt.Println("main:", filepath.Join(base, "main.jsonnet"))
 			fmt.Println("rootDir:", root)
 			fmt.Println("baseDir:", base)
 			fmt.Println("jpath:", path)
-			return nil
 		},
 	}
 	return cmd

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -12,11 +12,12 @@ import (
 
 func applyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "apply",
+		Use:   "apply [directory]",
 		Short: "apply the configuration to the cluster",
+		Args:  cobra.ExactArgs(1),
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(args[0])
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}
@@ -35,11 +36,12 @@ func applyCmd() *cobra.Command {
 
 func diffCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "diff",
+		Use:   "diff [directory]",
 		Short: "differences between the configuration and the cluster",
+		Args:  cobra.ExactArgs(1),
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(args[0])
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}
@@ -67,11 +69,12 @@ func diffCmd() *cobra.Command {
 
 func showCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show",
+		Use:   "show [directory]",
 		Short: "jsonnet as yaml",
+		Args:  cobra.ExactArgs(1),
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(args[0])
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/alecthomas/chroma v0.6.6
 	github.com/fatih/color v1.7.0
 	github.com/google/go-jsonnet v0.13.0
-	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYX
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/jpath/jpath.go
+++ b/pkg/jpath/jpath.go
@@ -14,22 +14,22 @@ import (
 // It then constructs a jPath with the base directory, vendor/ and lib/.
 // This results in predictable imports, as it doesn't matter whether the user called
 // called the command further down tree or not. A little bit like git.
-func Resolve(workdir string) (path []string, base, root string) {
-	root, err := findParentFile("jsonnetfile.json", workdir, "/")
+func Resolve(workdir string) (path []string, base, root string, err error) {
+	root, err = findParentFile("jsonnetfile.json", workdir, "/")
 	if err != nil {
-		panic(err)
+		return nil, "", "", err
 	}
 
 	base, err = findParentFile("main.jsonnet", workdir, root)
 	if err != nil {
-		panic(err)
+		return nil, "", "", err
 	}
 
 	return []string{
 		base,
 		filepath.Join(root, "vendor"),
 		filepath.Join(root, "lib"),
-	}, base, root
+	}, base, root, nil
 }
 
 // findParentFile traverses the parent directory tree for the given `file`,

--- a/pkg/jsonnet/jsonnet.go
+++ b/pkg/jsonnet/jsonnet.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	jsonnet "github.com/google/go-jsonnet"
+	"github.com/pkg/errors"
 	"github.com/sh0rez/tanka/pkg/jpath"
 	"github.com/sh0rez/tanka/pkg/native"
 )
@@ -16,7 +17,10 @@ func EvaluateFile(jsonnetFile string) (string, error) {
 		return "", err
 	}
 
-	jpath, _, _ := jpath.Resolve(filepath.Dir(jsonnetFile))
+	jpath, _, _, err := jpath.Resolve(filepath.Dir(jsonnetFile))
+	if err != nil {
+		return "", errors.Wrap(err, "resolving jpath")
+	}
 	return Evaluate(string(bytes), jpath)
 }
 


### PR DESCRIPTION
:warning: **This PR should be reviewed with together with #7, because they are tightly coupled and some smaller changes (error handling) have been addressed in that one.** :warning: 

The `baseDir` is the most important directory, because it directly affects `JPATH`
resolution.

It was assumed as the `pwd` so far. However, it is handy in scripts to specify it
on the command line. This behaviour switches to specify only.

To fully support this, it was required to rework the configuration system, because we need to parse the CLI flags first, before we can read in the config, due to the `spec.json` residing inside of the `baseDir`.

⚠️ **BREAKING**: You must specify the `baseDir` on the command line. To mimic the old
behaviour, use `tk show .`

Closes #4 