### PR TITLE
feat(jpath): allow other entrypoints than main.jsonnet

### DIFF
--- a/cmd/tk/debug.go
+++ b/cmd/tk/debug.go
@@ -27,8 +27,9 @@ func jpathCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			path, base, root := jpath.Resolve(pwd)
-			fmt.Println("main:", filepath.Join(base, "main.jsonnet"))
+			filename := cmd.Flag("file").Value.String()
+			path, base, root := jpath.Resolve(pwd, filename)
+			fmt.Println("main:", filepath.Join(base, filename))
 			fmt.Println("rootDir:", root)
 			fmt.Println("baseDir:", base)
 			fmt.Println("jpath:", path)

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -27,7 +27,7 @@ func evalCmd() *cobra.Command {
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		json, err := eval()
+		json, err := eval(cmd.Flag("file").Value.String())
 		if err != nil {
 			return err
 		}
@@ -38,24 +38,24 @@ func evalCmd() *cobra.Command {
 	return cmd
 }
 
-func eval() (string, error) {
+func eval(filename string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 
-	_, baseDir, _ := jpath.Resolve(pwd)
-	json, err := jsonnet.EvaluateFile(filepath.Join(baseDir, "main.jsonnet"))
+	_, baseDir, _ := jpath.Resolve(pwd, filename)
+	json, err := jsonnet.EvaluateFile(filepath.Join(baseDir, filename))
 	if err != nil {
 		return "", err
 	}
 	return json, nil
 }
 
-func evalDict() (map[string]interface{}, error) {
+func evalDict(filename string) (map[string]interface{}, error) {
 	var rawDict map[string]interface{}
 
-	raw, err := eval()
+	raw, err := eval(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -39,6 +39,7 @@ func main() {
 		},
 	}
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "")
+	rootCmd.PersistentFlags().StringP("file", "f", "main.jsonnet", "file to use as the entrypoint")
 
 	// Subcommands
 	cobra.EnableCommandSorting = false

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -16,7 +16,7 @@ func applyCmd() *cobra.Command {
 		Short: "apply the configuration to the cluster",
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(cmd.Flag("file").Value.String())
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}
@@ -39,7 +39,7 @@ func diffCmd() *cobra.Command {
 		Short: "differences between the configuration and the cluster",
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(cmd.Flag("file").Value.String())
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}
@@ -71,7 +71,7 @@ func showCmd() *cobra.Command {
 		Short: "jsonnet as yaml",
 	}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, err := evalDict()
+		raw, err := evalDict(cmd.Flag("file").Value.String())
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
 		}

--- a/pkg/jpath/jpath.go
+++ b/pkg/jpath/jpath.go
@@ -14,13 +14,13 @@ import (
 // It then constructs a jPath with the base directory, vendor/ and lib/.
 // This results in predictable imports, as it doesn't matter whether the user called
 // called the command further down tree or not. A little bit like git.
-func Resolve(workdir string) (path []string, base, root string) {
+func Resolve(workdir string, filename string) (path []string, base, root string) {
 	root, err := findParentFile("jsonnetfile.json", workdir, "/")
 	if err != nil {
 		panic(err)
 	}
 
-	base, err = findParentFile("main.jsonnet", workdir, root)
+	base, err = findParentFile(filename, workdir, root)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/jsonnet/jsonnet.go
+++ b/pkg/jsonnet/jsonnet.go
@@ -16,12 +16,14 @@ func EvaluateFile(jsonnetFile string) (string, error) {
 		return "", err
 	}
 
-	jpath, _, _ := jpath.Resolve(filepath.Dir(jsonnetFile))
-	return Evaluate(string(bytes), jpath)
+	filename := filepath.Base(jsonnetFile)
+	jpath, _, _ := jpath.Resolve(filepath.Dir(jsonnetFile), filename)
+
+	return Evaluate(string(bytes), filename, jpath)
 }
 
 // Evaluate renders the given jssonet into a string
-func Evaluate(sonnet string, jpath []string) (string, error) {
+func Evaluate(sonnet string, filename string, jpath []string) (string, error) {
 	importer := jsonnet.FileImporter{
 		JPaths: jpath,
 	}
@@ -32,5 +34,5 @@ func Evaluate(sonnet string, jpath []string) (string, error) {
 		vm.NativeFunction(nf)
 	}
 
-	return vm.EvaluateSnippet("main.jsonnet", sonnet)
+	return vm.EvaluateSnippet(filename, sonnet)
 }


### PR DESCRIPTION
Adds an optional flag `-f` / `--file` to specify the file to start
with (defaults stays main.jsonnet). File must be at the root of baseDir