### PR TITLE
feat(kubernetes): subset-diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/objx v0.2.0
+	github.com/stretchr/testify v1.3.0
 	github.com/thoas/go-funk v0.4.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f // indirect

--- a/pkg/config/v1alpha1/config.go
+++ b/pkg/config/v1alpha1/config.go
@@ -16,6 +16,7 @@ type Metadata struct {
 
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer string `json:"apiServer"`
-	Namespace string `json:"namespace"`
+	APIServer    string `json:"apiServer"`
+	Namespace    string `json:"namespace"`
+	DiffStrategy string `json:"diffStrategy"`
 }

--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -1,0 +1,11 @@
+package kubernetes
+
+import "fmt"
+
+type ErrorNotFound struct {
+	resource string
+}
+
+func (e ErrorNotFound) Error() string {
+	return fmt.Sprintf(`error from server (NotFound): secrets "%s" not found`, e.resource)
+}

--- a/pkg/kubernetes/subsetdiff.go
+++ b/pkg/kubernetes/subsetdiff.go
@@ -1,0 +1,131 @@
+package kubernetes
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/objx"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/sh0rez/tanka/pkg/util"
+)
+
+type difference struct {
+	live, merged string
+}
+
+func (k Kubectl) SubsetDiff(y string) (string, error) {
+	//          is     should
+	docs := map[string]difference{}
+	d := yaml.NewDecoder(strings.NewReader(y))
+	for {
+
+		// jsonnet output -> desired state
+		var rawShould map[interface{}]interface{}
+		err := d.Decode(&rawShould)
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return "", errors.Wrap(err, "decoding yaml")
+		}
+
+		// filename
+		m := objx.New(util.CleanupInterfaceMap(rawShould))
+		name := strings.Replace(fmt.Sprintf("%s.%s.%s.%s",
+			m.Get("apiVersion").MustStr(),
+			m.Get("kind").MustStr(),
+			m.Get("metadata.namespace").MustStr(),
+			m.Get("metadata.name").MustStr(),
+		), "/", "-", -1)
+
+		// kubectl output -> current state
+		rawIs, err := k.Get(
+			m.Get("metadata.namespace").MustStr(),
+			m.Get("kind").MustStr(),
+			m.Get("metadata.name").MustStr(),
+		)
+		if err != nil {
+			if _, ok := err.(ErrorNotFound); ok {
+				rawIs = map[string]interface{}{}
+			} else {
+				return "", errors.Wrap(err, "getting state from cluster")
+			}
+		}
+
+		should, err := yaml.Marshal(rawShould)
+		if err != nil {
+			return "", err
+		}
+
+		is, err := yaml.Marshal(subset(m, rawIs))
+		if err != nil {
+			return "", err
+		}
+		if string(is) == "{}\n" {
+			is = []byte("")
+		}
+		docs[name] = difference{string(is), string(should)}
+	}
+
+	s := ""
+	for k, v := range docs {
+		d, err := diff(k, v.live, v.merged)
+		if err != nil {
+			return "", errors.Wrap(err, "invoking diff")
+		}
+		if d != "" {
+			d += "\n"
+		}
+		s += d
+	}
+
+	return s, nil
+}
+
+// subset removes all keys from is, that are not present in should.
+// It makes is a subset of should.
+// Kubernetes returns more keys than we can know about.
+// This means, we need to remove all keys from the kubectl output, that are not present locally.
+func subset(should, is map[string]interface{}) map[string]interface{} {
+	if should["namespace"] != nil {
+		is["namespace"] = should["namespace"]
+	}
+	for k, v := range is {
+		if should[k] == nil {
+			delete(is, k)
+			continue
+		}
+
+		switch b := v.(type) {
+		case map[string]interface{}:
+			if a, ok := should[k].(map[string]interface{}); ok {
+				is[k] = subset(a, b)
+			}
+		case []map[string]interface{}:
+			for i := range b {
+				if a, ok := should[k].([]map[string]interface{}); ok {
+					b[i] = subset(a[i], b[i])
+				}
+			}
+		case []interface{}:
+			for i := range b {
+				if a, ok := should[k].([]interface{}); ok {
+					aa, ok := a[i].(map[string]interface{})
+					if !ok {
+						continue
+					}
+					bb, ok := b[i].(map[string]interface{})
+					if !ok {
+						continue
+					}
+					b[i] = subset(aa, bb)
+				}
+			}
+		}
+	}
+	return is
+}

--- a/pkg/kubernetes/subsetdiff.go
+++ b/pkg/kubernetes/subsetdiff.go
@@ -17,7 +17,6 @@ type difference struct {
 }
 
 func (k Kubectl) SubsetDiff(y string) (string, error) {
-	//          is     should
 	docs := map[string]difference{}
 	d := yaml.NewDecoder(strings.NewReader(y))
 	for {

--- a/pkg/kubernetes/subsetdiff_test.go
+++ b/pkg/kubernetes/subsetdiff_test.go
@@ -1,0 +1,137 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubset(t *testing.T) {
+	tests := []struct {
+		name       string
+		should, is map[string]interface{}
+		want       map[string]interface{}
+	}{
+		{
+			name: "simple",
+			should: map[string]interface{}{
+				"foo": "bar",
+				"bam": "boo",
+			},
+			is: map[string]interface{}{
+				"foo": "baz",
+				"baz": "bar",
+			},
+			want: map[string]interface{}{
+				"foo": "baz",
+			},
+		},
+		{
+			name: "nested",
+			should: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"foo": "bar",
+					"bar": "boo",
+				},
+			},
+			is: map[string]interface{}{
+				"foo": "bam",
+				"baz": map[string]interface{}{
+					"rab": "bar",
+					"bar": "foo",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bam",
+				"baz": map[string]interface{}{
+					"bar": "foo",
+				},
+			},
+		},
+		{
+			name: "slice",
+			should: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "bar",
+					},
+				},
+			},
+			is: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "baz",
+						"bam": "baz",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "baz",
+					},
+				},
+			},
+		},
+		{
+			name: "heterogeneous_slice",
+			should: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "bar",
+						"het": []interface{}{
+							"foobar",
+							map[string]interface{}{
+								"bam": "baz",
+							},
+						},
+					},
+				},
+			},
+			is: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "baz",
+						"het": []interface{}{
+							"foobam",
+							map[string]interface{}{
+								"bam": "bloo",
+								"boo": "boar",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": []map[string]interface{}{
+					{
+						"foo": "baz",
+						"het": []interface{}{
+							"foobam",
+							map[string]interface{}{
+								"bam": "bloo",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "namespace",
+			should: map[string]interface{}{
+				"namespace": "loki",
+			},
+			is: map[string]interface{}{},
+			want: map[string]interface{}{
+				"namespace": "loki",
+			},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, subset(c.should, c.is))
+		})
+	}
+}

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -1,0 +1,46 @@
+package kubernetes
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func diff(name, is, should string) (string, error) {
+	dir, err := ioutil.TempDir("", "diff")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(dir)
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "LIVE-"+name), []byte(is), os.ModePerm); err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "MERGED-"+name), []byte(should), os.ModePerm); err != nil {
+		return "", err
+	}
+
+	buf := bytes.Buffer{}
+	merged := filepath.Join(dir, "MERGED-"+name)
+	live := filepath.Join(dir, "LIVE-"+name)
+	cmd := exec.Command("diff", "-u", "-N", live, merged)
+	cmd.Stdout = &buf
+	err = cmd.Run()
+
+	// the diff utility exits with `1` if there are differences. We need to not fail there.
+	if exitError, ok := err.(*exec.ExitError); ok && err != nil {
+		if exitError.ExitCode() != 1 {
+			return "", err
+		}
+	}
+
+	out := buf.String()
+	if out != "" {
+		out = fmt.Sprintf("diff -u -N %s %s\n%s", live, merged, out)
+	}
+
+	return out, nil
+}

--- a/pkg/util/mapstr.go
+++ b/pkg/util/mapstr.go
@@ -1,0 +1,33 @@
+package util
+
+import "fmt"
+
+// CleanupInterfaceMap converts a map[interface]interface to map[string]interface
+func CleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return CleanupInterfaceMap(v)
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}


### PR DESCRIPTION
So far, diffing was offloaded to kubectl. While this produces very nice results,
it is only possible for kubernetes version 1.13+.

Nevertheless, there are older cluster versions around, so these need to be
supported as well. subset-diff addresses those cases in the hopefully best way
possible.

To reduce field bloat, it only diffes those fields, that are present in the
local config. Kubernetes adds dynamic fields on the fly which we cannot know
about, so this is required.

Note: You WILL NOT see removed fields in the diff output. Upgrade your cluster
version to 1.13+ and use native diffing.